### PR TITLE
Forge 1.19, 1.19.1, 1.19.2, 1.19.3 Curios Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Spyglass Improvements is a mod that add various functionality and improvements t
 
 
 ## ScreenShots:
-![Zoom Example](https://github.com/juancarloscp52/spyglass-improvements/blob/master/images/zoom.gif)
-![Clear Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/master/images/clear.png)
-![Circle Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/master/images/circle.png)
-![None Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/master/images/none.png)
+![Zoom Example](https://github.com/juancarloscp52/spyglass-improvements/blob/forge-1.19/images/zoom.gif?raw=true)
+![Clear Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/forge-1.19/images/clear.png?raw=true)
+![Circle Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/forge-1.19/images/circle.png?raw=true)
+![None Layout](https://github.com/juancarloscp52/spyglass-improvements/blob/forge-1.19/images/none.png?raw=true)
 
 ## Installation:
 This mod requires [Forge](https://files.minecraftforge.net/). You can download Spyglass Improvements from the [CurseForge page](https://www.curseforge.com/minecraft/mc-mods/spyglass-improvements), make sure to download the forge version.

--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,7 @@ repositories {
     // Put repositories for dependencies here
     // ForgeGradle automatically adds the Forge maven and Maven Central for you
 
-    // If you have mod jar dependencies in ./libs, you can declare them as a repository like so:
-    // flatDir {
-    //     dir 'libs'
-    // }
+    maven { url = "https://maven.theillusivec4.top/" }
 }
 
 dependencies {
@@ -111,9 +108,12 @@ dependencies {
 
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
+    // To test soft Curios dependency, (un)comment the runtimeOnly line below when running runClient and runServer tasks
+    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
+    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
+
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
-// Example for how to get properties into the manifest for reading at runtime.
 
 // To update mods.toml automatically from gradle.properties
 processResources {
@@ -122,6 +122,7 @@ processResources {
 
             minecraft_range: minecraft_range,
             forge_range: forge_range,
+            curios_range: curios_range,
 
             mod_id: mod_id,
             mod_version: mod_version,

--- a/build.gradle
+++ b/build.gradle
@@ -6,20 +6,24 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '[6.0,6.2)', changing: true
         classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
+}
+
+plugins {
+    id 'eclipse'
+    id 'idea'
 }
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 
 group = 'me.juancarloscp52'
-//version = "${project.mod_version}+mc${project.minecraft_version}+forge"
-version = "${project.mod_version}+mc${project.minecraft_version}+forge"
+version = "${mod_version}+mc${minecraft_version}+forge"
 
 java {
-    archivesBaseName = 'spyglass_improvements'
+    archivesBaseName = mod_id
     toolchain.languageVersion = JavaLanguageVersion.of(17)
 }
 
@@ -35,15 +39,15 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: "${project.minecraft_version}"
+    mappings channel: mapping_channel, version: mapping_version
+    copyIdeResources = true
 
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
-     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
-
-    // Default run configurations.
-    // These can be tweaked, removed, or duplicated as needed.
+    // Run configurations.
     runs {
-        client {
+        // Applies to all run configs below.
+        configureEach {
             workingDirectory project.file('run')
 
             // Recommended logging data for a userdev environment
@@ -63,53 +67,22 @@ minecraft {
                     source sourceSets.main
                 }
             }
+        }
+
+        client {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
         }
 
         server {
-            workingDirectory project.file('run')
-
-            // Recommended logging data for a userdev environment
-            // The markers can be added/removed as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
-
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
-
-            mods {
-                spyglass_improvements {
-                    source sourceSets.main
-                }
-            }
+            workingDirectory project.file('run/server')
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
         }
 
         data {
-            workingDirectory project.file('run')
-
-            // Recommended logging data for a userdev environment
-            // The markers can be added/removed as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
-
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
-
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', 'spyglass_improvements', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-
-            mods {
-                spyglass_improvements {
-                    source sourceSets.main
-                }
-            }
+            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
         }
     }
 }
@@ -133,26 +106,35 @@ repositories {
 }
 
 dependencies {
-    // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft' it is assumed
-    // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
-    // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft "net.minecraftforge:forge:${project.minecraft_version}-${project.forge_version}"
-
-    // Real mod deobf dependency examples - these get remapped to your current mappings
-    // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
-    // runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
-    // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${mc_version}-${registrate_version}") // Adds registrate as a dependency
-
-    // Examples using mod jars from ./libs
-    // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
-
-    // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
+
+    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
 // Example for how to get properties into the manifest for reading at runtime.
+
+// To update mods.toml automatically from gradle.properties
+processResources {
+    var replaceProperties = [
+            minecraft_version: minecraft_version,
+
+            minecraft_range: minecraft_range,
+            forge_range: forge_range,
+
+            mod_id: mod_id,
+            mod_version: mod_version,
+    ]
+
+    inputs.properties(replaceProperties)
+
+    filesMatching(['META-INF/mods.toml', 'pack.mcmeta']) {
+        expand replaceProperties + [project: project]
+    }
+}
+
+
 jar {
     manifest {
         attributes([

--- a/build.gradle
+++ b/build.gradle
@@ -118,14 +118,12 @@ dependencies {
 // To update mods.toml automatically from gradle.properties
 processResources {
     var replaceProperties = [
-            minecraft_version: minecraft_version,
+            mod_id: mod_id,
+            version: version,
 
             minecraft_range: minecraft_range,
             forge_range: forge_range,
-            curios_range: curios_range,
-
-            mod_id: mod_id,
-            mod_version: mod_version,
+            curios_range: curios_range
     ]
 
     inputs.properties(replaceProperties)

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,152 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+Find your version by looking for the file for your mod-loader:
+
+-   spyglass_improvements-`<mod-version>`+mc`<mc-version>`+forge.jar
+-   spyglass-improvements-`<mod-version>`+mc`<mc-version>`+fabric.jar
+
+## [2.0.0] - 2024-mm-dd
+
+Available versions:
+
+-   Forge: 1.18.2, 1.19, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4
+
+### Added
+
+-   Forge:
+    -   **[Curios API](https://www.curseforge.com/minecraft/mc-mods/curios)** support - Spyglass can now be equipped in the belt Curios slot and accessed via key-bind.
+
+### Changed
+
+-   Forge:
+    -   Mod now has a soft dependency on Curios API (on both client and server).
+        -   If Curios API is not installed, the mod will still work on the client as before.
+    -   Some backend code to make future updates easier.
+
+### Fixed
+
+-   Forge:
+    -   Fix a bug where the player's active inventory/hot-bar slot de-syncs after opening the inventory while scoping.
+        -   Instead of requiring the player to use the spyglass normally again to reset the slot, the spyglass remains where it was last used.
+
+## [1.4] - 2022-09-13
+
+Available versions:
+
+-   Fabric, Quilt: 1.19, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4
+-   Forge: 1.19, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4
+-   NeoForge: 1.20.2, 1.20.3, 1.20.4
+
+### Added
+
+-   Fabric, Quilt:
+    -   Can now use the spyglass and zoom while in third person.
+    -   (2022-12-08) Updated to 1.19.3
+    -   (2023-03-19) Updated to 1.19.4
+    -   (2023-06-07) Updated to 1.20 and 1.20.1
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean and Brazilian Portuguese translations.
+-   Forge:
+    -   Can now use the spyglass and zoom while in third person.
+    -   Updated to 1.19.3 and 1.19.4
+    -   (2023-06-18) Updated to 1.20 and 1.20.1
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation.
+-   NeoForge:
+    -   Can now use the spyglass and zoom while in third person.
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation.
+
+### Fixed
+
+-   Fabric, Quilt:
+    -   Fix key-binds not working with renamed spyglass.
+-   Forge, NeoForge:
+    -   Fix key-binds not working with renamed spyglass.
+    -   Fix key-binds not showing in the controls settings.
+
+## [1.3.1] - 2022-07-28
+
+Available versions:
+
+-   Forge: 1.19, 1.19.1, 1.19.2
+
+### Added
+
+-   Forge:
+    -   Updated to 1.19, 1.19.1, and 1.19.2
+
+### Fixed
+
+-   Forge:
+    -   Fixed incompatibility with newer Forge versions
+
+## [1.3] - 2022-06-08
+
+Available versions:
+
+-   Fabric: 1.19, 1.19.1, 1.19.2
+-   Forge: 1.19
+
+### Added
+
+-   Fabric:
+    -   Updated to 1.19, 1.19.1, and 1.19.2
+-   Forge:
+    -   Updated to 1.19
+
+### Fixed
+
+-   Fabric, Forge:
+    -   Play sound when interacting with the spyglass while on creative mode.
+
+## [1.2] - 2022-04-24
+
+Available versions:
+
+-   Fabric: 1.18.2
+-   Forge: 1.18.1, 1.18.2
+
+### Added
+
+-   Fabric, Forge:
+    -   Added option to hide the cross-hair while scoping.
+    -   Added option to enable smooth (cinematic) camera while scoping.
+
+## [1.1.1] - 2022-02-19
+
+Available versions:
+
+-   Forge: 1.18.1, 1.18.2
+
+### Fixed
+
+-   Forge:
+    -   Fix logical Server and Client side bugs.
+
+## [1.1] - 2022-02-11
+
+Available versions:
+
+-   Fabric: 1.18.1, 1.18.2
+-   Forge: 1.18.1
+
+### Added
+
+-   Fabric:
+    -   Re-release including fabric tag on jar to differentiate.
+    -   (2022-02-28) Updated to 1.18.2
+-   Forge:
+    -   Initial Forge Release
+
+## [1.0] - 2022-01-22
+
+Available versions:
+
+-   Fabric: 1.18.1
+
+### Added
+
+-   Fabric:
+    -   Initial Release

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@ Available versions:
 ### Added
 
 -   Forge:
-    -   **[Curios API](https://www.curseforge.com/minecraft/mc-mods/curios)** support - Spyglass can now be equipped in the belt Curios slot and accessed via key-bind.
+    -   **[Curios API](https://www.curseforge.com/minecraft/mc-mods/curios)** support - Spyglass can now be equipped in the belt Curios slot and accessed via key-bind (Thanks Kimchiloof).
 
 ### Changed
 
@@ -48,15 +48,15 @@ Available versions:
     -   (2022-12-08) Updated to 1.19.3
     -   (2023-03-19) Updated to 1.19.4
     -   (2023-06-07) Updated to 1.20 and 1.20.1
-    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean and Brazilian Portuguese translations.
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean and Brazilian Portuguese translations (Thanks Yusi0 and FITFC).
 -   Forge:
     -   Can now use the spyglass and zoom while in third person.
     -   Updated to 1.19.3 and 1.19.4
     -   (2023-06-18) Updated to 1.20 and 1.20.1
-    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation.
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation (Thanks Yusi0).
 -   NeoForge:
     -   Can now use the spyglass and zoom while in third person.
-    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation.
+    -   (2023-10-20) Updated to 1.20.2, 1.20.3, and 1.20.4, added Korean translation (Thanks Yusi0).
 
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,18 +4,18 @@ org.gradle.daemon=false
 # Dependencies
 
 minecraft_version=1.19
-minecraft_range=[1.19,1.20)
+minecraft_range=[1.19,1.19.4)
 
 mapping_channel=official
 mapping_version=1.19
 
 forge_version=41.1.0
-forge_range=[41,46)
+forge_range=[41,45)
 
 curios_version=1.19-5.1.0.4
-curios_range=[1.19,1.19.4-+]
+curios_range=[1.19,1.19.4)
 
 # Mod properties
 
 mod_id=spyglass_improvements
-mod_version=1.5.0
+mod_version=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,9 @@ mapping_version=1.19
 forge_version=41.1.0
 forge_range=[41,46)
 
+curios_version=1.19-5.1.0.4
+curios_range=[1.19,1.19.4-+]
+
 # Mod properties
 
 mod_id=spyglass_improvements

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,18 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=1.4
+
+# Dependencies
+
 minecraft_version=1.19
-forge_version = 41.0.100
+minecraft_range=[1.19,1.20)
+
+mapping_channel=official
+mapping_version=1.19
+
+forge_version=41.1.0
+forge_range=[41,46)
+
+# Mod properties
+
+mod_id=spyglass_improvements
+mod_version=1.5.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright Â© 2015-2021 the original authors.
+# Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
-#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
-#         * compound commands having a testable exit status, especially Â«caseÂ»;
-#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+}
+
 rootProject.name = 'spyglass_improvements'

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/SpyglassImprovements.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/SpyglassImprovements.java
@@ -2,11 +2,15 @@ package me.juancarloscp52.spyglass_improvements;
 
 
 import me.juancarloscp52.spyglass_improvements.config.SpyglassImprovementsConfig;
+import me.juancarloscp52.spyglass_improvements.curios.CuriosIntegration;
+import me.juancarloscp52.spyglass_improvements.curios.SpyglassCuriosRenderer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,7 +20,21 @@ public class SpyglassImprovements {
     public static final Logger LOGGER = LogManager.getLogger();
 
     public SpyglassImprovements() {
+        boolean curiosLoaded = ModList.get().isLoaded("curios");
+
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT,() ->()-> ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, SpyglassImprovementsConfig.SPEC));
+
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            if (curiosLoaded) {
+                SpyglassCuriosRenderer.register();
+            }
+        });
+
+        if (curiosLoaded) {
+            FMLJavaModLoadingContext.get().getModEventBus().addListener(CuriosIntegration::enqueueSlot);
+        } else {
+            LOGGER.warn("Curios API not found, skipping Spyglass Improvements and Curios integration");
+        }
     }
 
 }

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/curios/CuriosIntegration.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/curios/CuriosIntegration.java
@@ -1,0 +1,20 @@
+package me.juancarloscp52.spyglass_improvements.curios;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotTypeMessage;
+import top.theillusivec4.curios.api.SlotTypePreset;
+
+public class CuriosIntegration {
+    public static void enqueueSlot(final InterModEnqueueEvent evt) {
+        InterModComms.sendTo(CuriosApi.MODID, SlotTypeMessage.REGISTER_TYPE,
+                () -> SlotTypePreset.BELT.getMessageBuilder().build());
+    }
+
+    public static boolean verifySpyglassCurios(Player player) {
+        return CuriosApi.getCuriosHelper().findFirstCurio(player, Items.SPYGLASS).isPresent();
+    }
+}

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/curios/SpyglassCuriosRenderer.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/curios/SpyglassCuriosRenderer.java
@@ -1,0 +1,74 @@
+package me.juancarloscp52.spyglass_improvements.curios;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.client.CuriosRendererRegistry;
+import top.theillusivec4.curios.api.client.ICurioRenderer;
+
+public class SpyglassCuriosRenderer implements ICurioRenderer {
+    private static final Minecraft MC = Minecraft.getInstance();
+
+    public static void register() {
+        CuriosRendererRegistry.register(Items.SPYGLASS, SpyglassCuriosRenderer::new);
+    }
+
+    @Override
+    public <T extends LivingEntity, M extends EntityModel<T>> void render(
+            ItemStack stack,
+            SlotContext slotContext,
+            PoseStack poseStack,
+            RenderLayerParent<T, M> renderLayerParent,
+            MultiBufferSource renderTypeBuffer,
+            int light,
+            float limbSwing,
+            float limbSwingAmount,
+            float partialTicks,
+            float ageInTicks,
+            float netHeadYaw,
+            float headPitch
+    ) {
+        ItemRenderer itemRenderer = MC.getItemRenderer();
+        LivingEntity livingEntity = slotContext.entity();
+        BakedModel spyglassModel = itemRenderer.getModel(
+                Items.SPYGLASS.getDefaultInstance(),
+                MC.level,
+                MC.player,
+                1
+        );
+
+        poseStack.pushPose();
+
+        if (livingEntity.isCrouching()) {
+            poseStack.translate(0.0F, 0.15F, 0.32F);
+        }
+
+        poseStack.translate(0.16, 0.6, 0.16);
+        poseStack.mulPose(Direction.DOWN.getRotation());
+        poseStack.scale(0.7f, 0.7f, 0.7f);
+
+        itemRenderer.render(
+                stack,
+                TransformType.NONE,
+                true,
+                poseStack,
+                renderTypeBuffer,
+                light,
+                OverlayTexture.NO_OVERLAY,
+                spyglassModel
+        );
+
+        poseStack.popPose();
+    }
+}

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/events/EventsHandler.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/events/EventsHandler.java
@@ -1,5 +1,6 @@
 package me.juancarloscp52.spyglass_improvements.events;
 
+import me.juancarloscp52.spyglass_improvements.curios.CuriosIntegration;
 import me.juancarloscp52.spyglass_improvements.client.SpyglassImprovementsClient;
 import me.juancarloscp52.spyglass_improvements.config.SpyglassImprovementsConfig;
 import net.minecraft.client.Minecraft;
@@ -10,17 +11,17 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.client.event.InputEvent;
-import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 
 public class EventsHandler {
+    private static final Minecraft client = Minecraft.getInstance();
 
     @SubscribeEvent
     public void onFovModifier(ScopeFOVModifierEvent event){
@@ -29,25 +30,40 @@ public class EventsHandler {
 
     @SubscribeEvent
     public void onMouseScroll(InputEvent.MouseScrollingEvent event){
-        Minecraft client = Minecraft.getInstance();
+        if (client.player == null) return;
         LocalPlayer player = client.player;
-        if(player != null && player.isScoping() && client.options.getCameraType().isFirstPerson()){
-            SpyglassImprovementsClient.MULTIPLIER = Mth.clamp(SpyglassImprovementsClient.MULTIPLIER-(event.getScrollDelta() * SpyglassImprovementsConfig.multiplierDelta.get()), .1,.8);
-            player.playSound(SoundEvents.SPYGLASS_STOP_USING, 1.0f, (float)(1.0f+(1*(1- SpyglassImprovementsClient.MULTIPLIER)*(1- SpyglassImprovementsClient.MULTIPLIER))));
+
+        if (player.isScoping() && client.options.getCameraType().isFirstPerson()) {
+            SpyglassImprovementsClient.MULTIPLIER = Mth.clamp(
+                    SpyglassImprovementsClient.MULTIPLIER - (event.getScrollDelta() * SpyglassImprovementsConfig.multiplierDelta.get()),
+                    .1,
+                    .8
+            );
+            player.playSound(
+                    SoundEvents.SPYGLASS_STOP_USING,
+                    1.0f,
+                    (float) (1.0f + (1 * (1 - SpyglassImprovementsClient.MULTIPLIER) * (1- SpyglassImprovementsClient.MULTIPLIER)))
+            );
             event.setCanceled(true);
         }
     }
 
     @SubscribeEvent
-    public void onRenderGameOverlay(RenderGuiOverlayEvent.Pre event){
+    public void onRenderGameOverlay(RenderGuiOverlayEvent.Pre event) {
+        if (client.player == null) return;
 
-        if(event.getOverlay()== VanillaGuiOverlay.SPYGLASS.type()
-                && SpyglassImprovementsConfig.overlay.get()==SpyglassImprovementsConfig.Overlays.None){
+        if (
+                event.getOverlay() == VanillaGuiOverlay.SPYGLASS.type()
+                        && SpyglassImprovementsConfig.overlay.get()==SpyglassImprovementsConfig.Overlays.None
+        ) {
             event.setCanceled(true);
         }
 
-        if(event.getOverlay()==VanillaGuiOverlay.CROSSHAIR.type() && !SpyglassImprovementsConfig.showCrosshair.get()
-                && Minecraft.getInstance().player.isScoping()){
+        if (
+                event.getOverlay() == VanillaGuiOverlay.CROSSHAIR.type()
+                        && !SpyglassImprovementsConfig.showCrosshair.get()
+                        && client.player.isScoping()
+        ) {
             event.setCanceled(true);
         }
     }
@@ -56,18 +72,20 @@ public class EventsHandler {
     public int slot = -1;
     @SubscribeEvent
     public void onStopUsingItem (LivingEntityUseItemEvent.Stop event){
-        Minecraft client = Minecraft.getInstance();
+        if (client.player == null || client.gameMode == null) return;
+        LocalPlayer player = client.player;
+
         // When stop using, reset spyglass position if it was changed.
-        if(event.getEntity().level.isClientSide && SpyglassImprovementsClient.useSpyglass.consumeClick()){
+        if (event.getEntity().level.isClientSide && SpyglassImprovementsClient.useSpyglass.consumeClick()) {
             SpyglassImprovementsClient.useSpyglass.release();
             int slot = this.slot;
-            if(client.player.getOffhandItem().getItem().equals(Items.SPYGLASS)){
-                if(slot > 8) {
-                    client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, client.player);
+            if (player.getOffhandItem().getItem().equals(Items.SPYGLASS)) {
+                if (slot > 8) {
+                    client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, player);
                     this.slot = -1;
                 }
-            }else if(slot >= 0 && slot <=8) {
-                client.player.getInventory().selected = slot;
+            } else if (slot >= 0 && slot <= 8) {
+                player.getInventory().selected = slot;
             }
         }
     }
@@ -75,43 +93,60 @@ public class EventsHandler {
     public static boolean force_spyglass = false;
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event){
-        Minecraft client = Minecraft.getInstance();
-        if(null != client.player) {
-            if (SpyglassImprovementsClient.useSpyglass.isDown() && client.rightClickDelay == 0 && !client.player.isUsingItem()) {
-                if (!client.player.getOffhandItem().getItem().equals(Items.SPYGLASS)) {
-                    slot = findSlotByItem(client.player.getInventory(),Items.SPYGLASS);
-                    //If the spyglass is in the inventory, move it to the off hand
-                    if (slot >= 9) {
-                        client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, client.player);
-                        return;
-                    } else if (slot >= 0) {
-                        // If the item is in the hotbar, select the item and interact with it.
-                        int oldSlot = client.player.getInventory().selected;
-                        client.player.getInventory().selected = slot;
-                        slot = oldSlot;
-                        client.gameMode.useItem(client.player, InteractionHand.MAIN_HAND);
-                        return;
-                    }
-                    // On creative mode, we do not need to have a spyglass to use it
-                    if (client.player.isCreative() && !force_spyglass) {
-                        force_spyglass=true;
-                        client.player.playSound(SoundEvents.SPYGLASS_USE, 1.0f, 1.0f);
-                    }
-                } else {
-                    client.gameMode.useItem(client.player, InteractionHand.OFF_HAND);
+        if (client.player == null || client.gameMode == null) return;
+        LocalPlayer player = client.player;
+
+        if (
+                SpyglassImprovementsClient.useSpyglass.isDown()
+                        && client.rightClickDelay == 0
+                        && !player.isUsingItem()
+                        && !force_spyglass
+        ) {
+            // Player wants and is able to use spyglass
+            if (player.getOffhandItem().getItem().equals(Items.SPYGLASS)) {
+                // In offhand
+                client.gameMode.useItem(player, InteractionHand.OFF_HAND);
+
+            } else if (player.getMainHandItem().getItem().equals(Items.SPYGLASS)) {
+                // In main hand
+                client.gameMode.useItem(player, InteractionHand.MAIN_HAND);
+
+            } else if (player.isCreative()) {
+                // On creative mode, we do not need to have a spyglass to use it
+                forceUseSpyglass(player);
+
+            } else if (ModList.get().isLoaded("curios") && CuriosIntegration.verifySpyglassCurios(player)) {
+                // In curios slot
+                forceUseSpyglass(player);
+
+            } else {
+                // In inventory
+                slot = findSlotByItem(player.getInventory(), Items.SPYGLASS);
+
+                // If the spyglass is in the inventory, move it to the offhand
+                if (slot >= 9) {
+                    client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, player);
+                } else if (slot >= 0) {
+                    // If the item is in the hot-bar, select the item and interact with it.
+                    int oldSlot = player.getInventory().selected;
+                    player.getInventory().selected = slot;
+                    slot = oldSlot;
+                    client.gameMode.useItem(player, InteractionHand.MAIN_HAND);
                 }
             }
-            // Release force spyglass when not pressing the keybind
-            if(force_spyglass && !SpyglassImprovementsClient.useSpyglass.isDown()){
-                force_spyglass=false;
-                client.player.playSound(SoundEvents.SPYGLASS_STOP_USING, 1.0f, 1.0f);
-            }
+        } else if (
+                !SpyglassImprovementsClient.useSpyglass.isDown()
+                        && force_spyglass
+        ) {
+            // Release force spyglass when not pressing the key-bind
+            force_spyglass = false;
+            player.playSound(SoundEvents.SPYGLASS_STOP_USING, 1.0f, 1.0f);
         }
     }
 
 
     /**
-     * Finds a slot containing an itemstack of the given item type.
+     * Finds a slot containing an item stack of the given item type.
      * @param inventory - Players inventory.
      * @param item - Item type to search for.
      * @return Slot ID, -1 if item was not found.
@@ -123,5 +158,10 @@ public class EventsHandler {
             }
         }
         return -1;
+    }
+
+    private void forceUseSpyglass(LocalPlayer player) {
+        force_spyglass = true;
+        player.playSound(SoundEvents.SPYGLASS_USE, 1.0f, 1.0f);
     }
 }

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/events/EventsHandler.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/events/EventsHandler.java
@@ -69,7 +69,7 @@ public class EventsHandler {
     }
 
     // Tracks the slot were the spyglass is located
-    public int slot = -1;
+    public static int slot = -1;
     @SubscribeEvent
     public void onStopUsingItem (LivingEntityUseItemEvent.Stop event){
         if (client.player == null || client.gameMode == null) return;
@@ -78,14 +78,15 @@ public class EventsHandler {
         // When stop using, reset spyglass position if it was changed.
         if (event.getEntity().level.isClientSide && SpyglassImprovementsClient.useSpyglass.consumeClick()) {
             SpyglassImprovementsClient.useSpyglass.release();
-            int slot = this.slot;
+
             if (player.getOffhandItem().getItem().equals(Items.SPYGLASS)) {
                 if (slot > 8) {
                     client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, player);
-                    this.slot = -1;
+                    slot = -1;
                 }
             } else if (slot >= 0 && slot <= 8) {
                 player.getInventory().selected = slot;
+                slot = -1;
             }
         }
     }
@@ -103,6 +104,8 @@ public class EventsHandler {
                         && !force_spyglass
         ) {
             // Player wants and is able to use spyglass
+            slot = findSlotByItem(player.getInventory(), Items.SPYGLASS);
+
             if (player.getOffhandItem().getItem().equals(Items.SPYGLASS)) {
                 // In offhand
                 client.gameMode.useItem(player, InteractionHand.OFF_HAND);
@@ -120,12 +123,10 @@ public class EventsHandler {
                 forceUseSpyglass(player);
 
             } else {
-                // In inventory
-                slot = findSlotByItem(player.getInventory(), Items.SPYGLASS);
-
-                // If the spyglass is in the inventory, move it to the offhand
                 if (slot >= 9) {
+                    // If the spyglass is in the inventory, move it to the offhand
                     client.gameMode.handleInventoryMouseClick(0, slot, 40, ClickType.SWAP, player);
+                    client.gameMode.useItem(player, InteractionHand.OFF_HAND);
                 } else if (slot >= 0) {
                     // If the item is in the hot-bar, select the item and interact with it.
                     int oldSlot = player.getInventory().selected;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -3,56 +3,37 @@
 # The overall format is standard TOML format, v0.5.0.
 # Note that there are a couple of TOML lists in this file.
 # Find more information on toml format here:  https://github.com/toml-lang/toml
-# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
-modLoader="javafml" #mandatory
-# A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[41,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
-# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
-# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+
+modLoader="javafml"
+loaderVersion="${forge_range}"
 license="GNU GPL 3.0"
-# A URL to refer people to when problems occur with this mod
-issueTrackerURL="https://github.com/juancarloscp52/spyglass-improvements/issues" #optional
-# A list of mods - how many allowed here is determined by the individual mod loader
-[[mods]] #mandatory
-# The modid of the mod
-modId="spyglass_improvements" #mandatory
-# The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
-# ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
-# see the associated build.gradle script for how to populate this completely automatically during a build
-version="1.4+mc1.19.x" #mandatory
-# A display name for the mod
-displayName="Spyglass Improvements" #mandatory
+
+issueTrackerURL="https://github.com/juancarloscp52/spyglass-improvements/issues"
+
+[[mods]]
+modId="${mod_id}"
+version="${mod_version}+mc${minecraft_version}+forge"
+displayName="Spyglass Improvements"
 # A URL to query for updates for this mod. See the JSON update specification <here>
 #updateJSONURL="http://myurl.me/" #optional
-# A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="https://www.curseforge.com/minecraft/mc-mods/spyglass-improvements" #optional
-# A file name (in the root of the mod JAR) containing a logo for display
-logoFile="icon.png" #optional
-# A text field displayed in the mod UI
-#credits="Thanks for this example mod goes to Java" #optional
-# A text field displayed in the mod UI
-authors="juancarloscp52(Im_JC)" #optional
-# The description text for the mod (multi line!) (#mandatory)
+displayURL="https://www.curseforge.com/minecraft/mc-mods/spyglass-improvements"
+logoFile="icon.png"
+#credits="Thanks for this example mod goes to Java"
+authors="juancarloscp52(Im_JC)"
 description='''
 Enhance Minecraft's Spyglass with adjustable zoom, quick access and various spyglass overlays.
 '''
-# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.spyglass_improvements]] #optional
-   # the modid of the dependency
-   modId="forge" #mandatory
-   # Does this dependency have to exist - if not, ordering below must be specified
-   mandatory=true #mandatory
-   # The version range of the dependency
-   versionRange="[41,)" #mandatory
-   # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
-   ordering="NONE"
-   # Side this dependency is applied on - BOTH, CLIENT or SERVER
-   side="BOTH"
-# Here's another dependency
-[[dependencies.spyglass_improvements]]
-   modId="minecraft"
-   mandatory=true
-   # This version range declares a minimum of the current minecraft version up to but not including the next major version
-   versionRange="[1.19,1.20)"
-   ordering="NONE"
-   side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="forge"
+mandatory=true
+versionRange="${forge_range}"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="minecraft"
+mandatory=true
+versionRange="${minecraft_range}"
+ordering="NONE"
+side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,7 +18,7 @@ displayName="Spyglass Improvements"
 #updateJSONURL="http://myurl.me/" #optional
 displayURL="https://www.curseforge.com/minecraft/mc-mods/spyglass-improvements"
 logoFile="icon.png"
-#credits="Thanks for this example mod goes to Java"
+credits="Curios support by Kimchiloof"
 authors="juancarloscp52(Im_JC)"
 description='''
 Enhance Minecraft's Spyglass with adjustable zoom, quick access and various spyglass overlays.

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,7 +18,7 @@ displayName="Spyglass Improvements"
 #updateJSONURL="http://myurl.me/" #optional
 displayURL="https://www.curseforge.com/minecraft/mc-mods/spyglass-improvements"
 logoFile="icon.png"
-credits="Curios support by Kimchiloof"
+#credits="Thanks for this example mod goes to Java"
 authors="juancarloscp52(Im_JC)"
 description='''
 Enhance Minecraft's Spyglass with adjustable zoom, quick access and various spyglass overlays.

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -12,7 +12,7 @@ issueTrackerURL="https://github.com/juancarloscp52/spyglass-improvements/issues"
 
 [[mods]]
 modId="${mod_id}"
-version="${mod_version}+mc${minecraft_version}+forge"
+version="${version}"
 displayName="Spyglass Improvements"
 # A URL to query for updates for this mod. See the JSON update specification <here>
 #updateJSONURL="http://myurl.me/" #optional

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -37,3 +37,10 @@ mandatory=true
 versionRange="${minecraft_range}"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="curios"
+mandatory=false
+versionRange="${curios_range}"
+ordering="BEFORE"
+side="BOTH"

--- a/src/main/resources/data/curios/tags/items/belt.json
+++ b/src/main/resources/data/curios/tags/items/belt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:spyglass"
+  ]
+}


### PR DESCRIPTION
Branch specific info:
 - Tested on:
    - 1.19 with curios 1.19-5.1.0.4 and curios 1.19.2-5.1.4.4
    - 1.19.1, 1.19.2 with curios 1.19.2-5.1.4.4
    - 1.19.3 with curios 1.19.3-5.1.4.1
- 1.19.4 is now on another build as there was a single tiny change (why 😞) to the rendering code
  - If there's a way to be like `if (1.19.4) { import lib.x } else { import lib.y }` then they can be on a single build but i couldn't find a way to make em work :(
  - See #39 
  - Tested that on 1.19.4 with curios 1.19.4-5.1.5.4

## Added

- Curios support for Forge 1.19, 1.19.1, 1.19.2, 1.19.3
  - I tried making the spyglass move to offhand and using `useItem()`, but that doesn't seem to add an animation when using the spyglass (issue mentioned in #25)
- A changelog.md, I think I got most the previous updates but it might be slightly wrong (also missing date on this update cuz idk when/if this will be merged)

## Changed

- Curios should be required on both client and server sides
- I think changes should allow the mod to still be client-side only when Curios is not detected (hopefully that is the case)
   - Mainly my concern was with 1.18.2 and 1.19.x cuz I wasn't exactly sure if my registration was correct lol
- build.gradle, gradle.properties, and mods.toml should now be easier to switch configs and versions
- Opening the inventory while scoping now keeps the spyglass where it was left (i.e. hand/offhand) so there is no unexpected behaviour when scoping again

## Notes

- Since build.gradle now automatically adjusts the mod version based on the minecraft version, for building I always set the target minecraft version to be the lowest in the supported range (i.e., 1.19 for [1.19, 1.19.4), 1.20 for [1.20, 1.20.2), and 1.20.2 for [1.20.2, 1.21)
- Should close #3, #30 on Forge 1.19, 1.19.1, 1.19.2, 1.19.3, (and 1.19.4 on the other branch)
- Also kind of closes #32, no config option but using the curios slot does not do the temporary move to offhand (for now anyways, as the current implementation uses the `force_spyglass` method of scoping
- I haven't really used Fabric so I don't think I'll be adding support for Trinkets rn - maybe if someone else has the time


(force push was to clean up like 3 add attribution commits whoops lol)