### PR TITLE
Remove conflicting redirect from Forge 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,10 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.4.1")) {
+        jarJar.ranged(it, "[0.4.1,)")
+    }
 }
 
 // To update mods.toml automatically from gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ curios_range=[1.19,1.19.4)
 # Mod properties
 
 mod_id=spyglass_improvements
-mod_version=1.5
+mod_version=1.6

--- a/src/main/java/me/juancarloscp52/spyglass_improvements/mixin/MinecraftMixin.java
+++ b/src/main/java/me/juancarloscp52/spyglass_improvements/mixin/MinecraftMixin.java
@@ -1,16 +1,25 @@
 package me.juancarloscp52.spyglass_improvements.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.juancarloscp52.spyglass_improvements.client.SpyglassImprovementsClient;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-    @Redirect(method = "handleKeybinds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z", ordinal = 2))
-    public boolean handleInput(KeyMapping instance){
-        return instance.isDown() || SpyglassImprovementsClient.useSpyglass.isDown();
+
+    @WrapOperation(
+            method = "handleKeybinds",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z")
+    )
+    private boolean handleSpyglassInput(KeyMapping instance, Operation<Boolean> original) {
+        if (SpyglassImprovementsClient.useSpyglass.isDown()) {
+            return true;
+        } else {
+            return original.call(instance);
+        }
     }
 }


### PR DESCRIPTION
This PR removes the redirect from `MinecraftMixin` in favour of a modern `WrapOperation`, which is more compatible with mods. This change was necessary in order to add compatibility back to Controllable, which is also [still using Redirect](https://github.com/MrCrayfish/Controllable/blob/6bf4e16c8991ce2871dea72deaae389685f578ce/src/main/java/com/mrcrayfish/controllable/mixin/client/MinecraftMixin.java#L33C6-L39C6) on 1.19.2. 

Feel free to update the versioning as necessary, I just bumped it to be able to use it safely in the Raspberry Flavoured modpack.

This PR fixes #20, #56  and likely #6.